### PR TITLE
Add format package

### DIFF
--- a/.changeset/bright-adults-battle.md
+++ b/.changeset/bright-adults-battle.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/format": minor
+---
+
+initial release

--- a/packages/format/README.md
+++ b/packages/format/README.md
@@ -1,8 +1,9 @@
 # @obosbbl/format
 
-[![npm canary version](https://img.shields.io/npm/v/@obosbbl%2Fformat/canary.svg)](https://www.npmjs.com/package/@obosbbl/format)
+[![NPM Version](https://img.shields.io/npm/v/%40obosbbl%2Fformat)](https://www.npmjs.com/package/@obosbbl/format)
 
-Formatting functions for both 🇳🇴 and 🇸🇪 with zero dependencies.
+
+A collection of formatting functions for both 🇳🇴 and 🇸🇪 with zero dependencies.
 
 ## Install
 
@@ -14,7 +15,25 @@ npm install @obosbbl/format
 pnpm add @obosbbl/format
 ```
 
+## Usage
+
+The package has two entrypoints, one for `no` and one for `se`. That allows you to import for only the locale you need.
+
+Note that the methods are very lenient when attempting to format the input. It will strip all characters that aren't digits or letters before it applies the formatting.
+That way any existing format of the input won't affect the formatted output
+
+If unable to format the input, the method will return the (cleaned) input as is.
+
+```js
+// 🇳🇴 example
+import { formatOrganizationNumber } from '@obosbbl/format/no';
+formatOrganizationNumber('000000000') // => '000 000 000'
+
+// 🇸🇪 example
+import { formatOrganizationNumber } from '@obosbbl/format/se';
+formatOrganizationNumber('0000000000') // => '000000-0000'
+```
+
 ## Methods
 
-* organizationNumberFormatter
-* obosMembershipNumberFormatter
+* formatOrganizationNumber

--- a/packages/format/README.md
+++ b/packages/format/README.md
@@ -1,0 +1,20 @@
+# @obosbbl/format
+
+[![npm canary version](https://img.shields.io/npm/v/@obosbbl%2Fformat/canary.svg)](https://www.npmjs.com/package/@obosbbl/format)
+
+Formatting functions for both 🇳🇴 and 🇸🇪 with zero dependencies.
+
+## Install
+
+```sh
+# npm
+npm install @obosbbl/format
+
+# pnpm
+pnpm add @obosbbl/format
+```
+
+## Methods
+
+* organizationNumberFormatter
+* obosMembershipNumberFormatter

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@obosbbl/format",
+  "version": "0.0.0",
+  "description": "A collection of formatting methods for OBOS",
+  "repository": {
+    "url": "https://github.com/code-obos/public-frontend-modules"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    "./no": {
+      "types": "./dist/no.d.mts",
+      "default": "./dist/no.mjs"
+    },
+    "./se": {
+      "types": "./dist/se.d.mts",
+      "default": "./dist/se.mjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "bunchee"
+  },
+  "dependencies": {}
+}

--- a/packages/format/src/format.test.ts
+++ b/packages/format/src/format.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest';
+import { formatOrganizationNumber, formatPhoneNumber } from '.';
+
+describe('no', () => {
+  test.each([
+    ['22865500', '22 86 55 00'],
+    ['80000000', '800 00 000'],
+  ])('formatPhoneNumber(%s) -> %s', (input, expected) => {
+    expect(formatPhoneNumber(input, 'no')).toBe(expected);
+  });
+
+  test.each([['000000000', '000 000 000']])(
+    'formatOrganizationNumber(%s) -> %s',
+    (input, expected) => {
+      expect(formatOrganizationNumber(input, 'no')).toBe(expected);
+    },
+  );
+});
+
+describe('se', () => {
+  test.each([['0701234567', '070-123 45 67']])(
+    'formatPhoneNumber(%s) -> %s',
+    (input, expected) => {
+      expect(formatPhoneNumber(input, 'se')).toBe(expected);
+    },
+  );
+
+  test.each([['0000000000', '000000-0000']])(
+    'formatOrganizationNumber(%s) -> %s',
+    (input, expected) => {
+      expect(formatOrganizationNumber(input, 'se')).toBe(expected);
+    },
+  );
+});

--- a/packages/format/src/format.test.ts
+++ b/packages/format/src/format.test.ts
@@ -1,34 +1,27 @@
 import { describe, expect, test } from 'vitest';
-import { formatOrganizationNumber, formatPhoneNumber } from '.';
+import { formatOrganizationNumber as formatOrganizationNumberNo } from './no';
+import { formatOrganizationNumber as formatOrganizationNumberSe } from './se';
 
 describe('no', () => {
   test.each([
-    ['22865500', '22 86 55 00'],
-    ['80000000', '800 00 000'],
-  ])('formatPhoneNumber(%s) -> %s', (input, expected) => {
-    expect(formatPhoneNumber(input, 'no')).toBe(expected);
+    ['000000000', '000 000 000'],
+    ['000 000 000', '000 000 000'],
+    ['000-000-000', '000 000 000'],
+    ['abc', 'abc'],
+  ])('formatOrganizationNumber(%s) -> %s', (input, expected) => {
+    expect(formatOrganizationNumberNo(input)).toBe(expected);
   });
-
-  test.each([['000000000', '000 000 000']])(
-    'formatOrganizationNumber(%s) -> %s',
-    (input, expected) => {
-      expect(formatOrganizationNumber(input, 'no')).toBe(expected);
-    },
-  );
 });
 
 describe('se', () => {
-  test.each([['0701234567', '070-123 45 67']])(
-    'formatPhoneNumber(%s) -> %s',
-    (input, expected) => {
-      expect(formatPhoneNumber(input, 'se')).toBe(expected);
-    },
-  );
-
-  test.each([['0000000000', '000000-0000']])(
-    'formatOrganizationNumber(%s) -> %s',
-    (input, expected) => {
-      expect(formatOrganizationNumber(input, 'se')).toBe(expected);
-    },
-  );
+  test.each([
+    ['0000000000', '000000-0000'],
+    ['000000-0000', '000000-0000'],
+    ['000000 0000', '000000-0000'],
+    [' 000000 0000 ', '000000-0000'],
+    ['000', '000'],
+    ['abc', 'abc'],
+  ])('formatOrganizationNumber(%s) -> %s', (input, expected) => {
+    expect(formatOrganizationNumberSe(input)).toBe(expected);
+  });
 });

--- a/packages/format/src/no.ts
+++ b/packages/format/src/no.ts
@@ -1,0 +1,25 @@
+const ORG_NUMBER_FORMAT = /^(\d{3})(\d{3})(\d{3})$/;
+
+/**
+ * Format an organization number
+ * @example
+ * ```
+ * formatOrganizationNumber('000000000') // => '000 000 000'
+ * ```
+ */
+export function formatOrganizationNumber(number: string): string {
+  return number.replace(ORG_NUMBER_FORMAT, '$1 $2 $3');
+}
+
+const OBOS_MEMBERSHIP_NUMBER_FORMAT = /^(\d{3})(\d{2})(\d{2})$/;
+
+/**
+ * Format an OBOS membership number
+ * @example
+ * ```
+ * formatObosMembershipNumber('0000000') // => '000 00 00'
+ * ```
+ */
+export function formatObosMembershipNumber(number: string): string {
+  return number.replace(OBOS_MEMBERSHIP_NUMBER_FORMAT, '$1 $2 $3');
+}

--- a/packages/format/src/no.ts
+++ b/packages/format/src/no.ts
@@ -1,3 +1,5 @@
+import { replaceIfMatch } from './utils';
+
 const ORG_NUMBER_FORMAT = /^(\d{3})(\d{3})(\d{3})$/;
 
 /**
@@ -7,19 +9,6 @@ const ORG_NUMBER_FORMAT = /^(\d{3})(\d{3})(\d{3})$/;
  * formatOrganizationNumber('000000000') // => '000 000 000'
  * ```
  */
-export function formatOrganizationNumber(number: string): string {
-  return number.replace(ORG_NUMBER_FORMAT, '$1 $2 $3');
-}
-
-const OBOS_MEMBERSHIP_NUMBER_FORMAT = /^(\d{3})(\d{2})(\d{2})$/;
-
-/**
- * Format an OBOS membership number
- * @example
- * ```
- * formatObosMembershipNumber('0000000') // => '000 00 00'
- * ```
- */
-export function formatObosMembershipNumber(number: string): string {
-  return number.replace(OBOS_MEMBERSHIP_NUMBER_FORMAT, '$1 $2 $3');
+export function formatOrganizationNumber(input: string): string {
+  return replaceIfMatch(input, ORG_NUMBER_FORMAT, '$1 $2 $3');
 }

--- a/packages/format/src/se.ts
+++ b/packages/format/src/se.ts
@@ -1,7 +1,7 @@
-// Ensures feature parity with the Norwegian format module
-export { formatObosMembershipNumber } from './no';
+import { replaceIfMatch } from './utils';
 
 const ORG_NUMBER_FORMAT = /^(\d{6})(\d{4})$/;
+
 /**
  * Format an organization number
  * @example
@@ -9,6 +9,6 @@ const ORG_NUMBER_FORMAT = /^(\d{6})(\d{4})$/;
  * formatOrganizationNumber('0000000000') // => '000000-0000'
  * ```
  */
-export function formatOrganizationNumber(number: string): string {
-  return number.replace(ORG_NUMBER_FORMAT, '$1-$2');
+export function formatOrganizationNumber(input: string): string {
+  return replaceIfMatch(input, ORG_NUMBER_FORMAT, '$1-$2');
 }

--- a/packages/format/src/se.ts
+++ b/packages/format/src/se.ts
@@ -1,0 +1,14 @@
+// Ensures feature parity with the Norwegian format module
+export { formatObosMembershipNumber } from './no';
+
+const ORG_NUMBER_FORMAT = /^(\d{6})(\d{4})$/;
+/**
+ * Format an organization number
+ * @example
+ * ```
+ * formatOrganizationNumber('0000000000') // => '000000-0000'
+ * ```
+ */
+export function formatOrganizationNumber(number: string): string {
+  return number.replace(ORG_NUMBER_FORMAT, '$1-$2');
+}

--- a/packages/format/src/utils.ts
+++ b/packages/format/src/utils.ts
@@ -1,0 +1,12 @@
+export function replaceIfMatch(
+  input: string,
+  regex: RegExp,
+  replacerPattern: string,
+): string {
+  // We're extremely lenient when attemtping to format the input.
+  // We remove everything that isn't a letter or a number, that way we can get rid of any
+  // formatting that might already be present in the input, eg spaces, hyphens or dots
+  const cleaned = input.replace(/[^a-zA-Z0-9]/g, '');
+
+  return cleaned.replace(regex, replacerPattern);
+}

--- a/packages/format/tsconfig.json
+++ b/packages/format/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src/*"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}


### PR DESCRIPTION
Denne PRen legger til første pakke for dette monorepoet, `@obosbbl/format`. Pakken skal etter hvert inneholde div formateringsmetoder for no og se.

Nå i første omgang inneholder pakken kun en metode, `formatOrganiationNumber`. Dette fordi den er veldig enkel. Det er litt fler regler for telefonnummer i feks Sverige.... Det skal gå fort å legge til fler her. Vil bare få ut en aller første versjon av pakken 😅 

Pakken har to entrypoints, et for no og et for se. Tanken er at det skal være feature parity mellom de tilgjengelig formateringsmetodene til de forskjellige landene.

Jeg tenker at denne pakken ikke bør inneholde validering. Den vil bare forsøke å formatere inputen som best den kan. Validering kan vi løse i en egen pakke.

Bruk:
```js
// 🇳🇴 example
import { formatOrganizationNumber } from '@obosbbl/format/no';

formatOrganizationNumber('000000000') // => '000 000 000'
formatOrganizationNumber('000-000-000') // => '000 000 000'
formatOrganizationNumber('   000 000 000') // => '000 000 000'

// 🇸🇪 example
import { formatOrganizationNumber } from '@obosbbl/format/se';

formatOrganizationNumber('0000000000') // => '000000-0000'
```


På sikt ser jeg også for meg et slags kombinert entrypoint, hvor du kan spesifisere locale som en del av metoden. Dette for å gjøre det enklere for de som har multitenant apper. Holder dette utenfor akkurat nå.

```js
import { formatOrganizationNumber } from '@obosbbl/format';

formatOrganizationNumber('0000000000', { locale: 'se' }) // => '000000-0000'
```


## Avklaring

Hvordan skal metodene navngis?

* formatOrganizationNumber
* formatPostalCode
* formatPhoneNumber

Eller

* organizationNumberFormat
* postalCodeFormat
* phoneNumberFormat
