### PR TITLE
format: add formatObosMembershipNumber

### DIFF
--- a/packages/format/README.md
+++ b/packages/format/README.md
@@ -37,3 +37,4 @@ formatOrganizationNumber('0000000000') // => '000000-0000'
 ## Methods
 
 * formatOrganizationNumber
+* formatObosMembershipNumber

--- a/packages/format/src/format.test.ts
+++ b/packages/format/src/format.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'vitest';
-import { formatOrganizationNumber as formatOrganizationNumberNo } from './no';
-import { formatOrganizationNumber as formatOrganizationNumberSe } from './se';
+import {
+  formatObosMembershipNumber as formatObosMembershipNumberNo,
+  formatOrganizationNumber as formatOrganizationNumberNo,
+} from './no';
+import {
+  formatObosMembershipNumber as formatObosMembershipNumberSe,
+  formatOrganizationNumber as formatOrganizationNumberSe,
+} from './se';
 
 describe('no', () => {
   test.each([
@@ -24,4 +30,15 @@ describe('se', () => {
   ])('formatOrganizationNumber(%s) -> %s', (input, expected) => {
     expect(formatOrganizationNumberSe(input)).toBe(expected);
   });
+});
+
+test.each([
+  ['0000000', '000 00 00'],
+  ['000 00 00', '000 00 00'],
+  ['000-00-00', '000 00 00'],
+])('formatObosMembershipNumber(%s) -> %s', (input, expected) => {
+  // don't split these by country, since they're essentially the same method
+  // we still test both though, to ensure there's no difference between them
+  expect(formatObosMembershipNumberNo(input)).toBe(expected);
+  expect(formatObosMembershipNumberSe(input)).toBe(expected);
 });

--- a/packages/format/src/no.ts
+++ b/packages/format/src/no.ts
@@ -12,3 +12,16 @@ const ORG_NUMBER_FORMAT = /^(\d{3})(\d{3})(\d{3})$/;
 export function formatOrganizationNumber(input: string): string {
   return replaceIfMatch(input, ORG_NUMBER_FORMAT, '$1 $2 $3');
 }
+
+const OBOS_MEMBERSHIP_NUMBER_FORMAT = /^(\d{3})(\d{2})(\d{2})$/;
+
+/**
+ * Format an OBOS membership number
+ * @example
+ * ```
+ * formatObosMembershipNumber('0000000') // => '000 00 00'
+ * ```
+ */
+export function formatObosMembershipNumber(input: string): string {
+  return replaceIfMatch(input, OBOS_MEMBERSHIP_NUMBER_FORMAT, '$1 $2 $3');
+}

--- a/packages/format/src/se.ts
+++ b/packages/format/src/se.ts
@@ -12,3 +12,6 @@ const ORG_NUMBER_FORMAT = /^(\d{6})(\d{4})$/;
 export function formatOrganizationNumber(input: string): string {
   return replaceIfMatch(input, ORG_NUMBER_FORMAT, '$1-$2');
 }
+
+// just reexport the no method for API feature parity
+export { formatObosMembershipNumber } from './no';


### PR DESCRIPTION
Denne PRen legger til støtte for å formatere et OBOS medlemsnummer. Formatet er det samme som er brukt på _Min side_ på obos.no : `000 00 00`.

Akkurat for denne er metoden er formateringen lik for Norge og Sverige, så her reeksporter vi bare den svenske slik at APIet blir likt for begge entrypointene:

```js
import { formatObosMembershipNumber } from '@obosbbl/format/no';
import { formatObosMembershipNumber } from '@obosbbl/format/se';
```
