### PR TITLE
format: add formatPostalCode method

### DIFF
--- a/.changeset/wicked-tools-provide.md
+++ b/.changeset/wicked-tools-provide.md
@@ -1,0 +1,15 @@
+---
+"@obosbbl/format": minor
+---
+
+add `formatPostalCode` method.
+
+```js
+import { formatPostalCode} from '@obosbbl/format/no';
+
+formatPostalCode('0000') // => '0000'
+
+import { formatPostalCode } from '@obosbbl/format/se';
+
+formatPhoneNumber('00000') // => '000 00'
+```

--- a/packages/format/README.md
+++ b/packages/format/README.md
@@ -39,3 +39,4 @@ formatOrganizationNumber('0000000000') // => '000000-0000'
 * formatPhoneNumber
 * formatOrganizationNumber
 * formatObosMembershipNumber
+* formatPostalCode

--- a/packages/format/src/format.test.ts
+++ b/packages/format/src/format.test.ts
@@ -3,11 +3,13 @@ import {
   formatObosMembershipNumber as formatObosMembershipNumberNo,
   formatOrganizationNumber as formatOrganizationNumberNo,
   formatPhoneNumber as formatPhoneNumberNo,
+  formatPostalCode as formatPostalCodeNo,
 } from './no';
 import {
   formatObosMembershipNumber as formatObosMembershipNumberSe,
   formatOrganizationNumber as formatOrganizationNumberSe,
   formatPhoneNumber as formatPhoneNumberSe,
+  formatPostalCode as formatPostalCodeSe,
 } from './se';
 
 describe('no', () => {
@@ -26,6 +28,13 @@ describe('no', () => {
   ])('formatOrganizationNumber(%s) -> %s', (input, expected) => {
     expect(formatOrganizationNumberNo(input)).toBe(expected);
   });
+
+  test.each([['0000', '0000']])(
+    'formatPostalCode(%s) -> %s',
+    (input, expected) => {
+      expect(formatPostalCodeNo(input)).toBe(expected);
+    },
+  );
 });
 
 describe('se', () => {
@@ -63,6 +72,13 @@ describe('se', () => {
     ['abc', 'abc'],
   ])('formatOrganizationNumber(%s) -> %s', (input, expected) => {
     expect(formatOrganizationNumberSe(input)).toBe(expected);
+  });
+
+  test.each([
+    ['00000', '000 00'],
+    ['000 00', '000 00'],
+  ])('formatPostalCode(%s) -> %s', (input, expected) => {
+    expect(formatPostalCodeSe(input)).toBe(expected);
   });
 });
 

--- a/packages/format/src/no.ts
+++ b/packages/format/src/no.ts
@@ -57,13 +57,16 @@ export function formatObosMembershipNumber(input: string): string {
   return replaceIfMatch(input, OBOS_MEMBERSHIP_NUMBER_FORMAT, '$1 $2 $3');
 }
 
+const POSTAL_CODE_FORMAT = /^(\d{4})$/;
+
 /**
  * Format a postal code
+ *
  * @example
  * ```
  * format('0000') // => '0000'
  * ```
  */
 export function formatPostalCode(input: string): string {
-  return input;
+  return replaceIfMatch(input, POSTAL_CODE_FORMAT, '$1');
 }

--- a/packages/format/src/no.ts
+++ b/packages/format/src/no.ts
@@ -56,3 +56,14 @@ const OBOS_MEMBERSHIP_NUMBER_FORMAT = /^(\d{3})(\d{2})(\d{2})$/;
 export function formatObosMembershipNumber(input: string): string {
   return replaceIfMatch(input, OBOS_MEMBERSHIP_NUMBER_FORMAT, '$1 $2 $3');
 }
+
+/**
+ * Format a postal code
+ * @example
+ * ```
+ * format('0000') // => '0000'
+ * ```
+ */
+export function formatPostalCode(input: string): string {
+  return input;
+}

--- a/packages/format/src/se.ts
+++ b/packages/format/src/se.ts
@@ -68,6 +68,8 @@ export function formatOrganizationNumber(input: string): string {
   return replaceIfMatch(input, ORG_NUMBER_FORMAT, '$1-$2');
 }
 
+const POSTAL_CODE_FORMAT = /^(\d{3})(\d{2})$/;
+
 /**
  * Format a postal code
  * @example
@@ -76,7 +78,7 @@ export function formatOrganizationNumber(input: string): string {
  * ```
  */
 export function formatPostalCode(input: string): string {
-  return input;
+  return replaceIfMatch(input, POSTAL_CODE_FORMAT, '$1 $2');
 }
 
 // just reexport the no method for API feature parity

--- a/packages/format/src/se.ts
+++ b/packages/format/src/se.ts
@@ -68,5 +68,16 @@ export function formatOrganizationNumber(input: string): string {
   return replaceIfMatch(input, ORG_NUMBER_FORMAT, '$1-$2');
 }
 
+/**
+ * Format a postal code
+ * @example
+ * ```
+ * format('00000') // => '000 00'
+ * ```
+ */
+export function formatPostalCode(input: string): string {
+  return input;
+}
+
 // just reexport the no method for API feature parity
 export { formatObosMembershipNumber } from './no';


### PR DESCRIPTION
Denne PRen legger til en ny metode, `formatPostalCode` for å formatere postnummer.

Har gått for det navnet, i stedet for for eksempel `formatZipCode`, da postalCode er det som brukes i adresseobjektet til DTP.

Merk at denne funksjonen eeeeegentlig ikke gir så mye mening for 🇳🇴, men i 🇸🇪 er det faktisk formatering, og vi ønsker feature parity på metodene.

```js
import { formatPostalCode} from '@obosbbl/format/no';

formatPostalCode('0000') // => '0000'

import { formatPostalCode } from '@obosbbl/format/se';

formatPhoneNumber('00000') // => '000 00'
```