### PR TITLE
format: add default entrypoint

### DIFF
--- a/.changeset/witty-items-drive.md
+++ b/.changeset/witty-items-drive.md
@@ -1,0 +1,24 @@
+---
+"@obosbbl/format": minor
+---
+
+add default entrypoint for formatting functions.
+
+This makes it easier to support both Norwegian and Swedish formatting in the same project,
+but it requires you to specify the wanted locale as an options argument to the method.
+
+Example:
+```js
+// Combined 🇳🇴🇸🇪 example
+import { formatOrganizationNumber } from '@obosbbl/format';
+formatOrganizationNumber('000000000', { locale: 'no' }) // => '000 000 000'
+formatOrganizationNumber('0000000000', { locale: 'se' }) // => '000000-0000'
+
+// 🇳🇴 only example
+import { formatOrganizationNumber } from '@obosbbl/format/no';
+formatOrganizationNumber('000000000') // => '000 000 000'
+
+// 🇸🇪 only example
+import { formatOrganizationNumber } from '@obosbbl/format/se';
+formatOrganizationNumber('0000000000') // => '000000-0000'
+```

--- a/packages/format/README.md
+++ b/packages/format/README.md
@@ -17,7 +17,7 @@ pnpm add @obosbbl/format
 
 ## Usage
 
-The package has two entrypoints, one for `no` and one for `se`. That allows you to import for only the locale you need.
+The package has three entrypoints. The default entrypoints requires you to specify the locale as an options argument to the method. The package also exports entrypoints for `no` and `se` only methods. That allows you to import for only the locale you support if need be.
 
 Note that the methods are very lenient when attempting to format the input. It will strip all characters that aren't digits or letters before it applies the formatting.
 That way any existing format of the input won't affect the formatted output
@@ -25,11 +25,16 @@ That way any existing format of the input won't affect the formatted output
 If unable to format the input, the method will return the (cleaned) input as is.
 
 ```js
-// 🇳🇴 example
+// Combined 🇳🇴🇸🇪 example
+import { formatOrganizationNumber } from '@obosbbl/format';
+formatOrganizationNumber('000000000', { locale: 'no' }) // => '000 000 000'
+formatOrganizationNumber('0000000000', { locale: 'se' }) // => '000000-0000'
+
+// 🇳🇴 only example
 import { formatOrganizationNumber } from '@obosbbl/format/no';
 formatOrganizationNumber('000000000') // => '000 000 000'
 
-// 🇸🇪 example
+// 🇸🇪 only example
 import { formatOrganizationNumber } from '@obosbbl/format/se';
 formatOrganizationNumber('0000000000') // => '000000-0000'
 ```

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -14,6 +14,10 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
     "./no": {
       "types": "./dist/no.d.mts",
       "default": "./dist/no.mjs"

--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -1,0 +1,78 @@
+import {
+  formatObosMembershipNumber as _formatObosMembershipNumber,
+  formatOrganizationNumber as formatOrganizationNumberNo,
+  formatPhoneNumber as formatPhoneNumberNo,
+  formatPostalCode as formatPostalCodeNo,
+} from './no';
+import {
+  formatOrganizationNumber as formatOrganizationNumberSe,
+  formatPhoneNumber as formatPhoneNumberSe,
+  formatPostalCode as formatPostalCodeSe,
+} from './se';
+
+export type Locale = 'no' | 'se';
+
+type Options = {
+  locale: Locale;
+};
+
+/**
+ * Format a phone number
+ * @example
+ * ```
+ * formatPhoneNumber('00000000', { locale: 'no' }) // => '00 00 00 00'
+ * formatPhoneNumber('07012345678', { locale: 'se' }) // => '070-123 45 678'
+ * ```
+ */
+export function formatPhoneNumber(input: string, options: Options): string {
+  return options.locale === 'no'
+    ? formatPhoneNumberNo(input)
+    : formatPhoneNumberSe(input);
+}
+
+/**
+ * Format an organization number
+ * @example
+ * ```
+ * formatOrganizationNumber('000000000', { locale: 'no' }) // => '000 000 000'
+ * formatOrganizationNumber('0000000000', { locale: 'se' }) // => '000000-0000'
+ * ```
+ */
+export function formatOrganizationNumber(
+  input: string,
+  options: Options,
+): string {
+  return options.locale === 'no'
+    ? formatOrganizationNumberNo(input)
+    : formatOrganizationNumberSe(input);
+}
+
+/**
+ * Format a postal code
+ * @example
+ * ```
+ * formatPostalCode('0000', { locale: 'no' }) // => '0000'
+ * formatPostalCode('00000', { locale: 'se' }) // => '000 00'
+ * ```
+ */
+export function formatPostalCode(input: string, options: Options): string {
+  return options.locale === 'no'
+    ? formatPostalCodeNo(input)
+    : formatPostalCodeSe(input);
+}
+
+/**
+ * Format an OBOS membership number
+ * @example
+ * ```
+ * formatObosMembershipNumber('0000000', { locale: 'no' }) // => '000 00 00'
+ * formatObosMembershipNumber('0000000', { locale: 'se' }) // => '000 00 00'
+ * ```
+ */
+export function formatObosMembershipNumber(
+  input: string,
+  options: Options,
+): string {
+  // this is the same for no/se. But we want the APIs to be consistent...
+  return _formatObosMembershipNumber(input);
+}

--- a/packages/format/src/no.ts
+++ b/packages/format/src/no.ts
@@ -61,10 +61,9 @@ const POSTAL_CODE_FORMAT = /^(\d{4})$/;
 
 /**
  * Format a postal code
- *
  * @example
  * ```
- * format('0000') // => '0000'
+ * formatPostalCode('0000') // => '0000'
  * ```
  */
 export function formatPostalCode(input: string): string {

--- a/packages/format/src/se.ts
+++ b/packages/format/src/se.ts
@@ -74,7 +74,7 @@ const POSTAL_CODE_FORMAT = /^(\d{3})(\d{2})$/;
  * Format a postal code
  * @example
  * ```
- * format('00000') // => '000 00'
+ * formatPostalCode('00000') // => '000 00'
  * ```
  */
 export function formatPostalCode(input: string): string {


### PR DESCRIPTION
Når jeg skulle ta i bruk pakken i en kodebase som støttet både no og se ble det fort slitsomt å importere fra både no og se hver for seg.

Denne PRen legger til støtte for et default entrypoint, hvor du må sende inn ønsket locale som et options argument.