### PR TITLE
validation: add validateObosMembershipNumber()

### DIFF
--- a/.changeset/cool-planes-exercise.md
+++ b/.changeset/cool-planes-exercise.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/validation": minor
+---
+
+feat: add method `validateObosMembershipNumber()` to validate if the input value is a valid OBOS membership number.

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -28,7 +28,7 @@ validateOrganizationNumber('937052766') // => true
 validateOrganizationNumber('000') // => false
 
 // 🇸🇪 example
-import { validateOrganizationNumer } from '@obosbbl/validation/se';
+import { validateOrganizationNumber } from '@obosbbl/validation/se';
 validateOrganizationNumber('5592221054') // => true
 
 validateOrganizationNumber('000') // => false
@@ -47,8 +47,10 @@ Note that this currently allows any formatting characters, not just the just the
 import { validateOrganizationNumber } from '@obosbbl/validation/no';
 
 validateOrganizationNumber('937052766') // true
+
 // formatting characters disallowed by default
 validateOrganizationNumber('937 052 766') // false;
+
 // allow formatting characters
 validateOrganizationNumber('937 052 766', { allowFormatting: true }) // true;
 ```
@@ -60,6 +62,8 @@ validateOrganizationNumber('937 052 766', { allowFormatting: true }) // true;
   * supports mobileOnly option
 * validateOrganizationNumber
   * Check digit verification is currently only implemented for Norwegian organization numbers. For Swedish organiation numbers, we only check the length of the input. PRs are welcome to fix this.
+* validateObosMembershipNumber
+
 
 ## Example usage with Zod
 

--- a/packages/validation/src/no.ts
+++ b/packages/validation/src/no.ts
@@ -84,3 +84,22 @@ export function validateOrganizationNumber(
    */
   return mod11(value, [3, 2, 7, 6, 5, 4, 3, 2]);
 }
+
+/**
+ * Validates that the input value is an OBOS membership number.
+ * @example
+ * ```
+ * validateObosMembershipNumber('0000000') // => true
+ * ```
+ */
+export function validateObosMembershipNumber(
+  value: string,
+  options: PostalCodeOptions = {},
+): boolean {
+  if (options.allowFormatting) {
+    // biome-ignore lint/style/noParameterAssign:
+    value = stripFormatting(value);
+  }
+
+  return /^\d{7}$/.test(value);
+}

--- a/packages/validation/src/se.ts
+++ b/packages/validation/src/se.ts
@@ -83,3 +83,6 @@ export function validateOrganizationNumber(
 
   return /^\d{10}$/.test(value);
 }
+
+// just reexport the no method for API feature parity
+export { validateObosMembershipNumber } from './no';

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -44,6 +44,20 @@ describe('no', () => {
   ])('validateOrganizationNumber(%s) -> %s', (input, expected, options) => {
     expect(no.validateOrganizationNumber(input, options)).toBe(expected);
   });
+
+  test.each([
+    ['1234567', true, undefined],
+    // too short
+    ['123456', false, undefined],
+    // too long
+    ['12345678', false, undefined],
+
+    // formatting
+    ['123 45 67', false, { allowFormatting: false }],
+    ['123 45 67', true, { allowFormatting: true }],
+  ])('validateObosMembershipNumber(%s) -> %s', (input, expected, options) => {
+    expect(no.validateObosMembershipNumber(input, options)).toBe(expected);
+  });
 });
 
 describe('se', () => {
@@ -100,5 +114,19 @@ describe('se', () => {
     ['559222-1054', true, { allowFormatting: true }],
   ])('validateOrganizationNumber(%s) -> %s', (input, expected, options) => {
     expect(se.validateOrganizationNumber(input, options)).toBe(expected);
+  });
+
+  test.each([
+    ['1234567', true, undefined],
+    // too short
+    ['123456', false, undefined],
+    // too long
+    ['12345678', false, undefined],
+
+    // formatting
+    ['123 45 67', false, { allowFormatting: false }],
+    ['123 45 67', true, { allowFormatting: true }],
+  ])('validateObosMembershipNumber(%s) -> %s', (input, expected, options) => {
+    expect(se.validateObosMembershipNumber(input, options)).toBe(expected);
   });
 });


### PR DESCRIPTION
Denne PRen legger til ny funksjonalitet i validation-pakken: `validateObosMembershipNumber()`.

Dette er funksjonalitet som vi  har i nettsted som jeg heller ønsker å dra inn herfra.

For feature parity så legges denne inn både i no og se, selv om det egentlig er samme metode. Dette er det samme som vi gjorde for format-pakken, se https://github.com/code-obos/public-frontend-modules/pull/3.