### PR TITLE
format: add support for country code in phone number input

### DIFF
--- a/.changeset/sour-plums-look.md
+++ b/.changeset/sour-plums-look.md
@@ -1,0 +1,16 @@
+---
+"@obosbbl/format": patch
+---
+
+allow country code for phone number input in `formatPhoneNumber()`.
+
+Previously it was unable to format phone numbers with country codes (+47, +46), now it can.
+Note that the country code will _not_ be part of the formatted output.
+
+```js
+// 🇳🇴 example
+formatPhoneNumber('+4700000000') // => '00 00 00 00'
+
+// 🇸🇪 example
+formatPhoneNumber('+46303123456') // => '0303-12 34 56'
+```

--- a/packages/format/src/format.test.ts
+++ b/packages/format/src/format.test.ts
@@ -16,6 +16,8 @@ describe('no', () => {
   test.each([
     ['22865500', '22 86 55 00'],
     ['80000000', '800 00 000'],
+    // with country code
+    ['+4722865500', '22 86 55 00'],
   ])('formatPhoneNumber(%s) -> %s', (input, expected) => {
     expect(formatPhoneNumberNo(input)).toBe(expected);
   });
@@ -57,6 +59,8 @@ describe('se', () => {
     ['0303123456', '0303-12 34 56'],
     ['03031234567', '0303-123 45 67'],
     ['030312345678', '0303-123 456 78'],
+    // with country code
+    ['+46303123456', '0303-12 34 56'],
     // invalid, too long a number
     ['0303123456789', '0303123456789'],
   ])('formatPhoneNumber(%s) -> %s', (input, expected) => {

--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -17,11 +17,15 @@ type Options = {
 };
 
 /**
- * Format a phone number
+ * Format a phone number.
+ *
+ * Country code can be present in the input, but it will be removed in the formatted output.
+ *
  * @example
  * ```
  * formatPhoneNumber('00000000', { locale: 'no' }) // => '00 00 00 00'
  * formatPhoneNumber('07012345678', { locale: 'se' }) // => '070-123 45 678'
+ * formatPhoneNumber('+4700000000', { locale: 'no' }) // => '00 00 00 00'
  * ```
  */
 export function formatPhoneNumber(input: string, options: Options): string {

--- a/packages/format/src/no.ts
+++ b/packages/format/src/no.ts
@@ -7,14 +7,22 @@ const REGULAR_PHONE_NUMBER_FORMAT = /^(\d{2})(\d{2})(\d{2})(\d{2})$/;
 const EIGHT_HUNDRED_SERIES_PHONE_NUMBER_FORMAT = /^(\d{3})(\d{2})(\d{3})$/;
 
 /**
- * Format a phone number
+ * Format a phone number.
+ *
+ * Country code can be present in the input, but it will be removed in the formatted output.
+ *
  * @example
  * ```
  * formatPhoneNumber('00000000') // => '00 00 00 00'
  * formatPhoneNumber('80000000') // => '800 00 000'
+ * formatPhoneNumber('+4700000000') // => '00 00 00 00'
  * ```
  */
 export function formatPhoneNumber(input: string): string {
+  // remove country code
+  // biome-ignore lint/style/noParameterAssign:
+  input = input.replace(/^\+47/, '');
+
   const number = replaceIfMatch(
     input,
     REGULAR_PHONE_NUMBER_FORMAT,

--- a/packages/format/src/se.ts
+++ b/packages/format/src/se.ts
@@ -14,16 +14,23 @@ const THREE_DIGIT_AREA_CODE =
   /^0(11|13|16|18|19|21|23|26|31|33|35|36|40|42|44|46|54|60|63|90)/;
 
 /**
- * Format a phone number
+ * Format a phone number.
+ *
+ * Country code can be present in the input, but it will be removed in the formatted output.
+ *
  * @example
  * ```
  * formatPhoneNumber('07012345678') // => '070-123 45 678'
  * formatPhoneNumber('0812345') // => '08-123 45'
  * formatPhoneNumber('0311234567') // => '031-123 45 67'
  * formatPhoneNumber('0303123456') // => '0303-12 34 56'
+ * formatPhoneNumber('+46303123456') // => '0303-12 34 56'
  * ```
  */
 export function formatPhoneNumber(input: string): string {
+  // biome-ignore lint/style/noParameterAssign:
+  input = input.replace(/^\+46/, '0');
+
   const normalizedInput = cleanInput(input);
 
   if (MOBILE_PHONE_NUMBER_FORMAT.test(normalizedInput)) {


### PR DESCRIPTION
Denne PRen legger til støtte for landekoder på inputen i `formatPhoneNumber()`.

Tidligere ville den ikke klare å formatere telefonnummeret om input verdien startet med `+47` eller `+46`. Merk at landekoden ikke blir med i den formaterte outputen.