### PR TITLE
add validation of Swedish national identity number

### DIFF
--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -40,7 +40,6 @@ The methods are "strict" by default, meaning no formatting characters in the inp
 This is preferrable, for instance when doing server-side validation, where the input is often expected to be a "clean" value.
 
 If you want to allow formatting characters in the input, you can pass `allowFormatting: true` in the options object to the method.
-Note that this currently allows any formatting characters, not just the just the "expected" ones for the input type.
 
 
 ```js

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -31,6 +31,7 @@
     "build": "bunchee"
   },
   "devDependencies": {
-    "nav-faker": "3.2.4"
+    "@personnummer/generate": "^1.0.3",
+    "nav-faker": "^3.2.4"
   }
 }

--- a/packages/validation/src/no.ts
+++ b/packages/validation/src/no.ts
@@ -113,11 +113,7 @@ type NationalIdentityNumberOptions = ValidatorOptions;
  *
  * @example
  * ```
- * // Fødselsnummer
- * validatePersonalIdentityNumber('21075417753') // => true
- *
- * // D-nummer
- * validatePersonalIdentityNumber('53097248016') // => true
+ * validatePersonalIdentityNumber('DDMMYYXXXXX') // => true
  * ```
  */
 export function validateNationalIdentityNumber(

--- a/packages/validation/src/no.ts
+++ b/packages/validation/src/no.ts
@@ -1,5 +1,5 @@
 import type { ValidatorOptions } from './types';
-import { mod11, stripFormatting } from './utils';
+import { isValidDate, mod11, stripFormatting } from './utils';
 
 type PostalCodeOptions = ValidatorOptions;
 
@@ -161,8 +161,5 @@ export function validateNationalIdentityNumber(
     day = day - 40;
   }
 
-  // important to use UTC so the user's timezone doesn't affect the validation
-  const date = new Date(Date.UTC(year, month - 1, day));
-
-  return date && date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+  return isValidDate(year, month, day);
 }

--- a/packages/validation/src/no.ts
+++ b/packages/validation/src/no.ts
@@ -104,7 +104,7 @@ export function validateObosMembershipNumber(
   return /^\d{7}$/.test(value);
 }
 
-type PersonalIdentityNumberOptions = ValidatorOptions;
+type NationalIdentityNumberOptions = ValidatorOptions;
 
 /**
  * Validates that the input value is a Norwegian national identity number (fødselsnummer or d-nummer).
@@ -122,7 +122,7 @@ type PersonalIdentityNumberOptions = ValidatorOptions;
  */
 export function validateNationalIdentityNumber(
   value: string,
-  options: PersonalIdentityNumberOptions = {},
+  options: NationalIdentityNumberOptions = {},
 ): boolean {
   if (options.allowFormatting) {
     // biome-ignore lint/style/noParameterAssign:

--- a/packages/validation/src/se.ts
+++ b/packages/validation/src/se.ts
@@ -122,7 +122,7 @@ export function validateNationalIdentityNumber(
   // copy/inspiration from NAV https://github.com/navikt/fnrvalidator/blob/77e57f0bc8e3570ddc2f0a94558c58d0f7259fe0/src/validator.ts#L108
   let year = Number(value.substring(0, 2 + add));
   const month = Number(value.substring(2 + add, 4 + add));
-  const day = Number(value.substring(4 + add, 6 + add));
+  let day = Number(value.substring(4 + add, 6 + add));
 
   // 1900 isn't a leap year, but 2000 is. Since JS two digits years to the Date constructor is an offset from the year 1900
   // we need to special handle that case. For other cases it doesn't really matter if the year is 1925 or 2025.
@@ -130,10 +130,10 @@ export function validateNationalIdentityNumber(
     year = 2000;
   }
 
-  // for a d-number the day is increased by 40. Eg the 31st of a month would be 71, or the 3rd would be 43.
-  // thus we need to subtract 40 to get the correct day of the month
-  if (day > 40) {
-    day = day - 40;
+  // for a samordningsnummer the day is increased by 60. Eg the 31st of a month would be 91, or the 3rd would be 63.
+  // thus we need to subtract 60 to get the correct day of the month
+  if (day > 60) {
+    day = day - 60;
   }
 
   return isValidDate(year, month, day);

--- a/packages/validation/src/se.ts
+++ b/packages/validation/src/se.ts
@@ -133,7 +133,7 @@ export function validateNationalIdentityNumber(
     return false;
   }
 
-  // when verifying the value, we must always use the short format, discaring the century
+  // when verifying the value, we must always use the short format, discarding the century
   // if we include the century it would generate a different checksum
   const isValid = mod10(`${yearStr}${monthStr}${dayStr}${rest}`);
   if (!isValid) {

--- a/packages/validation/src/se.ts
+++ b/packages/validation/src/se.ts
@@ -153,7 +153,8 @@ export function validateNationalIdentityNumber(
       const date = new Date();
       const baseYear =
         separator === '+' ? date.getUTCFullYear() - 100 : date.getUTCFullYear();
-      year = baseYear - ((baseYear - yearStr) % 100);
+      year =
+        baseYear - ((baseYear - Number.parseInt(yearStr as string, 10)) % 100);
       break;
     }
     // if it's the short format, without a separator, we need to special handle the year for the date validation.
@@ -176,7 +177,7 @@ export function validateNationalIdentityNumber(
     day = day - 60;
   }
 
-  return isValidDate(year, month, day, centuryStr || separator);
+  return isValidDate(year, month, day, Boolean(centuryStr || separator));
 }
 
 // just reexport the no method for API feature parity

--- a/packages/validation/src/se.ts
+++ b/packages/validation/src/se.ts
@@ -87,16 +87,16 @@ export function validateOrganizationNumber(
 type PersonalIdentityNumberOptions = ValidatorOptions;
 
 /**
- * Validates that the input value is a Swedish national identity number (fødselsnummer or d-nummer).
+ * Validates that the input value is a Swedish national identity number (personnummer or samordningsnummer).
  *
  * It validates the control digits and checks if the date of birth is valid.
  *
  * @example
  * ```
- * // Fødselsnummer
+ * // Personnummer
  * validatePersonalIdentityNumber('21075417753') // => true
  *
- * // D-nummer
+ * // Samordningsnummer
  * validatePersonalIdentityNumber('53097248016') // => true
  * ```
  */
@@ -128,6 +128,12 @@ export function validateNationalIdentityNumber(
   // we need to special handle that case. For other cases it doesn't really matter if the year is 1925 or 2025.
   if (year === 0) {
     year = 2000;
+  }
+
+  // for a d-number the day is increased by 40. Eg the 31st of a month would be 71, or the 3rd would be 43.
+  // thus we need to subtract 40 to get the correct day of the month
+  if (day > 40) {
+    day = day - 40;
   }
 
   return isValidDate(year, month, day);

--- a/packages/validation/src/utils.ts
+++ b/packages/validation/src/utils.ts
@@ -26,3 +26,49 @@ export function mod11(value: string, weights: number[]): boolean {
 
   return controlNumber === Number(value[value.length - 1]);
 }
+
+/**
+ * Also known as Luhn's algorithm.
+ * Used to validate Swedish national identity numbers.
+ * See https://no.wikipedia.org/wiki/MOD10
+ */
+export function mod10(value: string): boolean {
+  let sum = 0;
+
+  for (let i = 0; i < value.length; ++i) {
+    const weight = 2 - (i % 2);
+
+    let number = Number(value[i]);
+
+    number = weight * number;
+
+    // if the number is greater than 9, ie more than one digit, we reduce it to a single digit by adding the individual digits together
+    // 7 * 2 => 14 => 1 + 4 => 5
+    // instead of adding the digits together, we can subtract 9 for the same result
+    // 7 * 2 => 14 => 14 - 9 => 5
+    if (number > 9) {
+      number = number - 9;
+    }
+
+    sum += number;
+  }
+
+  return sum % 10 === 0;
+}
+
+export function isValidDate(year: number, month: number, day: number): boolean {
+  // months are zero indexed 🤷‍♂️
+  month -= 1;
+
+  // important to use UTC so the user's timezone doesn't affect the validation
+  const date = new Date(Date.UTC(year, month, day));
+
+  return (
+    date &&
+    // cannot do this for Norway
+    // maybe do it for Sweden?
+    // date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month &&
+    date.getUTCDate() === day
+  );
+}

--- a/packages/validation/src/utils.ts
+++ b/packages/validation/src/utils.ts
@@ -29,15 +29,17 @@ export function mod11(value: string, weights: number[]): boolean {
 
 /**
  * Also known as Luhn's algorithm.
- * Used to validate Swedish national identity numbers.
- * See https://no.wikipedia.org/wiki/MOD10
+ * Used to validate Swedish national identity numbers and Norwegian KID numbers
+ *
+ * See https://no.wikipedia.org/wiki/MOD10 and https://sv.wikipedia.org/wiki/Luhn-algoritmen#Kontroll_av_nummer
  */
 export function mod10(value: string): boolean {
   let sum = 0;
 
-  for (let i = 0; i < value.length; ++i) {
-    const weight = 2 - (i % 2);
-
+  let weight = 1;
+  // loop in reverse, starting with 1 as the weight for the last digit
+  // which is control digit
+  for (let i = value.length - 1; i >= 0; --i) {
     let number = Number(value[i]);
 
     number = weight * number;
@@ -51,6 +53,8 @@ export function mod10(value: string): boolean {
     }
 
     sum += number;
+    // alternate between 1 and 2 for the weight
+    weight = weight === 1 ? 2 : 1;
   }
 
   return sum % 10 === 0;
@@ -66,7 +70,7 @@ export function isValidDate(year: number, month: number, day: number): boolean {
   return (
     date &&
     // cannot do this for Norway
-    // maybe do it for Sweden?
+    // maybe do it for Sweden for long format?
     // date.getUTCFullYear() === year &&
     date.getUTCMonth() === month &&
     date.getUTCDate() === day

--- a/packages/validation/src/utils.ts
+++ b/packages/validation/src/utils.ts
@@ -57,7 +57,7 @@ export function mod10(value: string): boolean {
 }
 
 export function isValidDate(year: number, month: number, day: number): boolean {
-  // months are zero indexed 🤷‍♂️
+  // biome-ignore lint/style/noParameterAssign: months are zero index 🤷‍♂️
   month -= 1;
 
   // important to use UTC so the user's timezone doesn't affect the validation

--- a/packages/validation/src/utils.ts
+++ b/packages/validation/src/utils.ts
@@ -60,18 +60,24 @@ export function mod10(value: string): boolean {
   return sum % 10 === 0;
 }
 
-export function isValidDate(year: number, month: number, day: number): boolean {
+export function isValidDate(
+  year: number,
+  month: number,
+  day: number,
+  /** Whether to check the year as part of the date validation. */
+  validateYear = false,
+): boolean {
   // biome-ignore lint/style/noParameterAssign: months are zero index 🤷‍♂️
   month -= 1;
 
   // important to use UTC so the user's timezone doesn't affect the validation
   const date = new Date(Date.UTC(year, month, day));
 
+  const validYear = validateYear ? date.getUTCFullYear() === year : true;
+
   return (
     date &&
-    // cannot do this for Norway
-    // maybe do it for Sweden for long format?
-    // date.getUTCFullYear() === year &&
+    validYear &&
     date.getUTCMonth() === month &&
     date.getUTCDate() === day
   );

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -223,7 +223,7 @@ describe('se', () => {
     }
   });
 
-  test('validateNationalIdentityNumber() - handles leap years', () => {
+  test.only('validateNationalIdentityNumber() - handles leap years', () => {
     expect(se.validateNationalIdentityNumber('0002297422')).toBe(true);
   });
 });

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -180,13 +180,35 @@ describe('se', () => {
     expect(se.validateObosMembershipNumber(input, options)).toBe(expected);
   });
 
-  test('validateNationalIdentityNumber() - validates leap years', () => {
+  test('test with leap years', () => {
+    expect(
+      se.validateOrganizationNumber('000229-3017', { allowFormatting: true }),
+    ).toBe(true);
+
+    expect(
+      se.validateOrganizationNumber('000229-5855', { allowFormatting: true }),
+    ).toBe(true);
+  });
+
+  test('validateNationalIdentityNumber() - validates short format personnummer', () => {
     for (let i = 0; i < 1000; ++i) {
       const pnr = swedishPersonNummer({ format: 'short' });
       expect(
         se.validateNationalIdentityNumber(pnr, { allowFormatting: true }),
         `${pnr} is valid`,
       ).toBe(true);
+    }
+  });
+
+  // 204101052241
+  // 211802018075
+  // 196304076083
+  test.only('validateNationalIdentityNumber() - validates long format personnummer', () => {
+    for (let i = 0; i < 1000; ++i) {
+      const pnr = swedishPersonNummer({ format: 'long' });
+      expect(se.validateNationalIdentityNumber(pnr), `${pnr} is valid`).toBe(
+        true,
+      );
     }
   });
 });

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -180,32 +180,32 @@ describe('se', () => {
     expect(se.validateObosMembershipNumber(input, options)).toBe(expected);
   });
 
-  test('test with leap years', () => {
-    expect(
-      se.validateOrganizationNumber('000229-3017', { allowFormatting: true }),
-    ).toBe(true);
-
-    expect(
-      se.validateOrganizationNumber('000229-5855', { allowFormatting: true }),
-    ).toBe(true);
-  });
-
-  test('validateNationalIdentityNumber() - validates short format personnummer', () => {
+  test('validateNationalIdentityNumber() - validates short format (YYMMDDXXXX) personnummer', () => {
     for (let i = 0; i < 1000; ++i) {
-      const pnr = swedishPersonNummer({ format: 'short' });
+      const pnrWithSeparator = swedishPersonNummer({ format: 'short' });
+      const pnrWithoutSeparator = pnrWithSeparator.replace(/[-+]/, '');
+
       expect(
-        se.validateNationalIdentityNumber(pnr, {
+        se.validateNationalIdentityNumber(pnrWithSeparator, {
           allowFormatting: true,
           format: 'short',
         }),
-        `${pnr} is valid`,
+        `${pnrWithSeparator} is valid with separator`,
+      ).toBe(true);
+
+      expect(
+        se.validateNationalIdentityNumber(pnrWithoutSeparator, {
+          format: 'short',
+        }),
+        `${pnrWithSeparator} is valid without separator`,
       ).toBe(true);
     }
   });
 
-  test('validateNationalIdentityNumber() - validates long format personnummer', () => {
+  test('validateNationalIdentityNumber() - validates long format (YYYYMMDDXXXX) personnummer', () => {
     for (let i = 0; i < 1000; ++i) {
       const pnr = swedishPersonNummer({ format: 'long' });
+
       expect(
         se.validateNationalIdentityNumber(pnr, { format: 'long' }),
         `${pnr} is valid`,
@@ -213,17 +213,53 @@ describe('se', () => {
     }
   });
 
-  test('validateNationalIdentityNumber() - validates long format personnummer', () => {
-    for (let i = 0; i < 1000; ++i) {
-      const pnr = swedishPersonNummer({ format: 'long' });
-      expect(
-        se.validateNationalIdentityNumber(pnr, { format: 'long' }),
-        `${pnr} is valid`,
-      ).toBe(true);
-    }
-  });
-
-  test.only('validateNationalIdentityNumber() - handles leap years', () => {
+  test('validateNationalIdentityNumber() - handles separator/leap years', () => {
+    // 29th of February is the best way to test whether the separator and long/short handling works correctly.
+    // The 29th of February year 2000 is valid a valid date, while the 29th of February year 1900 is not.
+    // That means we get different results based on the separator.
     expect(se.validateNationalIdentityNumber('0002297422')).toBe(true);
+    expect(
+      se.validateNationalIdentityNumber('000229-7422', {
+        allowFormatting: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      se.validateNationalIdentityNumber('000229+7422', {
+        allowFormatting: true,
+      }),
+    ).toBe(false);
+
+    expect(se.validateNationalIdentityNumber('190002297422')).toBe(false);
+  });
+
+  test('validateNationalIdentityNumber() - validates samordningsnummer', () => {
+    expect(
+      se.validateNationalIdentityNumber('701063-2391', {
+        allowFormatting: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('validateNationalIdentityNumber() - respects format modifier', () => {
+    expect(
+      se.validateNationalIdentityNumber(
+        swedishPersonNummer({ format: 'short' }),
+        {
+          allowFormatting: true,
+          format: 'long',
+        },
+      ),
+    ).toBe(false);
+
+    expect(
+      se.validateNationalIdentityNumber(
+        swedishPersonNummer({ format: 'long' }),
+        {
+          allowFormatting: true,
+          format: 'short',
+        },
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -194,21 +194,22 @@ describe('se', () => {
     for (let i = 0; i < 1000; ++i) {
       const pnr = swedishPersonNummer({ format: 'short' });
       expect(
-        se.validateNationalIdentityNumber(pnr, { allowFormatting: true }),
+        se.validateNationalIdentityNumber(pnr, {
+          allowFormatting: true,
+          format: 'short',
+        }),
         `${pnr} is valid`,
       ).toBe(true);
     }
   });
 
-  // 204101052241
-  // 211802018075
-  // 196304076083
-  test.only('validateNationalIdentityNumber() - validates long format personnummer', () => {
+  test('validateNationalIdentityNumber() - validates long format personnummer', () => {
     for (let i = 0; i < 1000; ++i) {
       const pnr = swedishPersonNummer({ format: 'long' });
-      expect(se.validateNationalIdentityNumber(pnr), `${pnr} is valid`).toBe(
-        true,
-      );
+      expect(
+        se.validateNationalIdentityNumber(pnr, { format: 'long' }),
+        `${pnr} is valid`,
+      ).toBe(true);
     }
   });
 });

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -1,3 +1,4 @@
+import swedishPersonNummer from '@personnummer/generate';
 import navfaker from 'nav-faker/dist/index';
 import { describe, expect, test } from 'vitest';
 import * as no from './no';
@@ -177,5 +178,15 @@ describe('se', () => {
     ['123 45 67', true, { allowFormatting: true }],
   ])('validateObosMembershipNumber(%s) -> %s', (input, expected, options) => {
     expect(se.validateObosMembershipNumber(input, options)).toBe(expected);
+  });
+
+  test('validateNationalIdentityNumber() - validates leap years', () => {
+    for (let i = 0; i < 1000; ++i) {
+      const pnr = swedishPersonNummer({ format: 'short' });
+      expect(
+        se.validateNationalIdentityNumber(pnr, { allowFormatting: true }),
+        `${pnr} is valid`,
+      ).toBe(true);
+    }
   });
 });

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -212,4 +212,18 @@ describe('se', () => {
       ).toBe(true);
     }
   });
+
+  test('validateNationalIdentityNumber() - validates long format personnummer', () => {
+    for (let i = 0; i < 1000; ++i) {
+      const pnr = swedishPersonNummer({ format: 'long' });
+      expect(
+        se.validateNationalIdentityNumber(pnr, { format: 'long' }),
+        `${pnr} is valid`,
+      ).toBe(true);
+    }
+  });
+
+  test('validateNationalIdentityNumber() - handles leap years', () => {
+    expect(se.validateNationalIdentityNumber('0002297422')).toBe(true);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,11 @@ importers:
 
   packages/validation:
     devDependencies:
+      '@personnummer/generate':
+        specifier: ^1.0.3
+        version: 1.0.3
       nav-faker:
-        specifier: 3.2.4
+        specifier: ^3.2.4
         version: 3.2.4
 
 packages:
@@ -352,6 +355,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@personnummer/generate@1.0.3':
+    resolution: {integrity: sha512-2wnl6FLM+ImyqjnIvyDXTwj5Nk2oDT+WLqJO3kYhzbu/ZDh2F/mfkJQwCpmyEUCZJuwGI3agF2zRD6H9ZS3g9A==}
 
   '@rollup/plugin-commonjs@28.0.2':
     resolution: {integrity: sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==}
@@ -1793,6 +1799,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.0
+
+  '@personnummer/generate@1.0.3': {}
 
   '@rollup/plugin-commonjs@28.0.2(rollup@4.34.8)':
     dependencies:


### PR DESCRIPTION
Denne PRen følger opp https://github.com/code-obos/public-frontend-modules/pull/31, og legger til støtte for validering av [svenske personnummer](https://sv.wikipedia.org/wiki/Personnummer_i_Sverige).

Det er inkludert støtte for [samordningsnummer](https://sv.wikipedia.org/wiki/Personnummer_i_Sverige#Andra_nummer), som er omtrent det samme som D-nummer i Norge.
 

Et svensk personnummer valideres med [MOD10/Luhns algoritme](https://no.wikipedia.org/wiki/MOD10). Så det er implementert her. (Brukes også til validere blant annet norske kid-nummer og svenske orgnummer, så dette får vi bruk for andre steder også).

Som vanlig har Sverige flere formater... Ofte brukes 10 siffer i det daglige, mens 12 siffer brukes til for eksempel lagring i svenske skatteverket, se [Wikipedia](https://sv.wikipedia.org/wiki/Personnummer_i_Sverige#Personnumrets_uppbyggnad).

Implementasjonen her støtter begge by default, men du kan skru på dette med en option, `format`
```js
// short
validatePersonalIdentityNumber('YYMMDDXXXX') // true
// long
validatePersonalIdentityNumber('YYYYMMDDXXXX') // true
// validate short format
validatePersonalIdentityNumber('YYYYMMDDXXXX', { format: 'short' ) // false
```

I tillegg så kan svenske personnummer formateres med en separator, men separatoren har signifikans. Til vanlig benyttes `YYMMDD-XXXX`, men dersom personen er over 100 år endres `-` til en `+`, altså  `YYMMDD+XXXX`. Dermed kan man lese av århundre i personnummeret selv om det bare er satt av to siffer til år i 10-siffer versjonen.

Dette er interessant, for det gjør at APIet man har brukt på de andre valideringsmetodene kanskje ikke helt passer til denne metoden. Alle metodene har en option, `allowFormatting`. Tanken var at den skulle brukes for å strippe vekk diverse forskjellige formatering av feks telefonnummer, eller om et kontonummer har blitt formatert med space eller punktum.

For at et personnummer på formatet `YYMMDD-XXXX` skal validere må man altså bruke metoden slik:
```js
validatePersonalIdentityNumber('YYMMDD-XXXX', { allowFormatting: true })
```

Jeg er ikke helt sikker på hva jeg synes om det. Så tar gjerne innspill. Ønsker vi at vi skal prøve å holde det likt for alle metoder, altså med `allowFormatting`?

Eller gir det mening at man endrer til feks `allowSeparator` for personnummer, men beholder `allowFormatting` feks på telefonnummer?

Her er forøvrig en fin resurss for å generere syntetiske personnummer for alle de fire formatene som vi støtter her 😄  https://fnr.mujaj.dev/