### PR TITLE
validation: add checksum validation of Swedish organization numbers

### DIFF
--- a/.changeset/tall-symbols-enjoy.md
+++ b/.changeset/tall-symbols-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@obosbbl/validation": patch
+---
+
+add checksum validation of Swedish organization numbers. Previously we only checked the length of the number.

--- a/packages/validation/src/se.ts
+++ b/packages/validation/src/se.ts
@@ -81,7 +81,7 @@ export function validateOrganizationNumber(
     value = stripFormatting(value);
   }
 
-  return /^\d{10}$/.test(value);
+  return /^\d{10}$/.test(value) && mod10(value);
 }
 
 type NationalIdentityNumberFormat = 'short' | 'long';


### PR DESCRIPTION
Siste før ny release

Siden vi fikk på plass [mod10](https://no.wikipedia.org/wiki/MOD10) for å validere svenske personnummer, så er det nå en meget enkel sak å ta i bruk denne for å validere svenske organisasjonsnummer også.

Tidligere sjekket vi kun lengden på svenske orgnummer.

Se https://sv.wikipedia.org/wiki/Organisationsnummer