### PR TITLE
validation: add norwegian bank account number

### DIFF
--- a/.changeset/tiny-bobcats-buy.md
+++ b/.changeset/tiny-bobcats-buy.md
@@ -4,8 +4,7 @@
 
 add method `no/validateAccountNumber()`
 
-Validates that the input is a valid Norwegian national identity number (either a fødselsnummer or a D-nummer).
-It validates the checksum and checks if the date of birth is valid.
+Validates that the input is a valid Norwegian bank account number.
 
 ```
     import { validateAccountNumber } from "@obosbbl/validation/no";

--- a/.changeset/tiny-bobcats-buy.md
+++ b/.changeset/tiny-bobcats-buy.md
@@ -1,0 +1,15 @@
+---
+"@obosbbl/validation": patch
+---
+
+add method `no/validateAccountNumber()`
+
+Validates that the input is a valid Norwegian national identity number (either a fødselsnummer or a D-nummer).
+It validates the checksum and checks if the date of birth is valid.
+
+```
+    import { validateAccountNumber } from "@obosbbl/validation/no";
+
+    validateAccountNumber('12345678903') // => true
+
+```

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -157,6 +157,19 @@ import { validateObosMembershipNumber } from '@obosbbl/validation/se';
 validateObosMembershipNumber('0000000') // => true
 ```
 
+### validateBankAccountNumber()
+
+Validates that the value is a valid organization number. Validates the checksum of the number.
+
+```js
+// 🇳🇴 example
+import { validateBankAccountNumber } from '@obosbbl/validation/no';
+validateBankAccountNumber('12345678903'); // => true
+
+// 🇸🇪 example
+// TODO: implement
+```
+
 
 ## Example usage with Zod
 

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -163,8 +163,8 @@ Validates that the value is a valid organization number. Validates the checksum 
 
 ```js
 // 🇳🇴 example
-import { validateBankAccountNumber } from '@obosbbl/validation/no';
-validateBankAccountNumber('12345678903'); // => true
+import { validateAccountNumber } from '@obosbbl/validation/no';
+validateAccountNumber('12345678903'); // => true
 
 // 🇸🇪 example
 // TODO: implement

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -157,7 +157,7 @@ import { validateObosMembershipNumber } from '@obosbbl/validation/se';
 validateObosMembershipNumber('0000000') // => true
 ```
 
-### validateBankAccountNumber()
+### validateAccountNumber()
 
 Validates that the value is a valid organization number. Validates the checksum of the number.
 

--- a/packages/validation/src/no.ts
+++ b/packages/validation/src/no.ts
@@ -159,3 +159,9 @@ export function validateNationalIdentityNumber(
 
   return isValidDate(year, month, day);
 }
+
+export function validateBankAccountNumber(value: string): boolean {
+  // Norwegian bank account numbers use mod 11 with one control digits.
+  // The first one is calculated for all 11 digits
+  return mod11(value, [5, 4, 3, 2, 7, 6, 5, 4, 3, 2]);
+}

--- a/packages/validation/src/no.ts
+++ b/packages/validation/src/no.ts
@@ -160,7 +160,27 @@ export function validateNationalIdentityNumber(
   return isValidDate(year, month, day);
 }
 
-export function validateAccountNumber(value: string): boolean {
+type AccountNumberOptions = ValidatorOptions;
+
+/**
+ * Validates that the input value is a Norwegian bank account number (kontonummer).
+ *
+ * It validates the control digit.
+ *
+ * @example
+ * ```
+ * validateAccountNumber('XXXXXXXXXXX') // => true
+ * ```
+ */
+export function validateAccountNumber(
+  value: string,
+  options: AccountNumberOptions = {},
+): boolean {
+  if (options.allowFormatting) {
+    // biome-ignore lint/style/noParameterAssign:
+    value = stripFormatting(value);
+  }
+
   // Norwegian bank account numbers use mod 11 with one control digits.
   // The first one is calculated for all 11 digits
   return mod11(value, [5, 4, 3, 2, 7, 6, 5, 4, 3, 2]);

--- a/packages/validation/src/no.ts
+++ b/packages/validation/src/no.ts
@@ -160,7 +160,7 @@ export function validateNationalIdentityNumber(
   return isValidDate(year, month, day);
 }
 
-export function validateBankAccountNumber(value: string): boolean {
+export function validateAccountNumber(value: string): boolean {
   // Norwegian bank account numbers use mod 11 with one control digits.
   // The first one is calculated for all 11 digits
   return mod11(value, [5, 4, 3, 2, 7, 6, 5, 4, 3, 2]);

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -54,7 +54,7 @@ describe('no', () => {
     ['95230820052', false],
     ['9523.08.20059', false],
   ])('validateAccountNumber(%s) -> %s', (input, expected) => {
-    expect(no.validateBankAccountNumber(input)).toBe(expected);
+    expect(no.validateAccountNumber(input)).toBe(expected);
   });
 
   test.each([

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -48,6 +48,16 @@ describe('no', () => {
   });
 
   test.each([
+    ['12345678903', true],
+    ['12345678901', false],
+    ['9523 08 20059', false],
+    ['95230820052', false],
+    ['9523.08.20059', false],
+  ])('validateAccountNumber(%s) -> %s', (input, expected) => {
+    expect(no.validateBankAccountNumber(input)).toBe(expected);
+  });
+
+  test.each([
     ['1234567', true, undefined],
     // too short
     ['123456', false, undefined],

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -48,13 +48,18 @@ describe('no', () => {
   });
 
   test.each([
-    ['12345678903', true],
-    ['12345678901', false],
-    ['9523 08 20059', false],
-    ['95230820052', false],
-    ['9523.08.20059', false],
-  ])('validateAccountNumber(%s) -> %s', (input, expected) => {
-    expect(no.validateAccountNumber(input)).toBe(expected);
+    ['12345678903', true, undefined],
+    ['12345678901', false, undefined],
+    ['1234 56 78903', false, undefined],
+    ['95230820052', false, undefined],
+    ['9523.08.20059', false, undefined],
+
+    ['1234 56 78903', true, { allowFormatting: true }],
+    ['1234 56 78903', false, { allowFormatting: false }],
+    ['9523.08.20059', true, { allowFormatting: true }],
+    ['9523.08.20059', false, { allowFormatting: false }],
+  ])('validateAccountNumber(%s) -> %s', (input, expected, options) => {
+    expect(no.validateAccountNumber(input, options)).toBe(expected);
   });
 
   test.each([


### PR DESCRIPTION
implementerer bare for norge da sverige har 100 forskjellige måter å validere kontonummer

sykt enkelt når det først var satt opp mod11 funksjon :D 

usikker på navngiving:

- bankAccountNumber
- accountNumber (lener meg mot denne egentlig)

Vil vi har formatering? tillate feks `12345 67 8903` eller `12345.67.8903` 