### PR TITLE
feat(format): add Norwegian account number formatting

### DIFF
--- a/.changeset/fresh-otters-count.md
+++ b/.changeset/fresh-otters-count.md
@@ -1,0 +1,5 @@
+---
+'@obosbbl/format': minor
+---
+
+Add Norwegian account number formatting.

--- a/packages/format/README.md
+++ b/packages/format/README.md
@@ -43,5 +43,6 @@ formatOrganizationNumber('0000000000') // => '000000-0000'
 
 * formatPhoneNumber
 * formatOrganizationNumber
+* formatAccountNumber
 * formatObosMembershipNumber
 * formatPostalCode

--- a/packages/format/src/format.test.ts
+++ b/packages/format/src/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  formatAccountNumber as formatAccountNumberNo,
   formatObosMembershipNumber as formatObosMembershipNumberNo,
   formatOrganizationNumber as formatOrganizationNumberNo,
   formatPhoneNumber as formatPhoneNumberNo,
@@ -29,6 +30,15 @@ describe('no', () => {
     ['abc', 'abc'],
   ])('formatOrganizationNumber(%s) -> %s', (input, expected) => {
     expect(formatOrganizationNumberNo(input)).toBe(expected);
+  });
+
+  test.each([
+    ['00000000000', '0000 00 00000'],
+    ['0000 00 00000', '0000 00 00000'],
+    ['0000.00.00000', '0000 00 00000'],
+    ['abc', 'abc'],
+  ])('formatAccountNumber(%s) -> %s', (input, expected) => {
+    expect(formatAccountNumberNo(input)).toBe(expected);
   });
 
   test.each([['0000', '0000']])(

--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  formatAccountNumber as _formatAccountNumber,
   formatObosMembershipNumber as _formatObosMembershipNumber,
   formatOrganizationNumber as formatOrganizationNumberNo,
   formatPhoneNumber as formatPhoneNumberNo,
@@ -14,6 +15,10 @@ export type Locale = 'no' | 'se';
 
 type Options = {
   locale: Locale;
+};
+
+type NorwegianOptions = {
+  locale: 'no';
 };
 
 /**
@@ -49,6 +54,21 @@ export function formatOrganizationNumber(
   return options.locale === 'no'
     ? formatOrganizationNumberNo(input)
     : formatOrganizationNumberSe(input);
+}
+
+/**
+ * Format a Norwegian account number
+ * @example
+ * ```
+ * formatAccountNumber('00000000000', { locale: 'no' }) // => '0000 00 00000'
+ * ```
+ */
+export function formatAccountNumber(
+  input: string,
+  options: NorwegianOptions,
+): string {
+  // This is currently a Norwegian-only formatter. Keep the options argument for API consistency.
+  return _formatAccountNumber(input);
 }
 
 /**

--- a/packages/format/src/no.ts
+++ b/packages/format/src/no.ts
@@ -52,6 +52,19 @@ export function formatOrganizationNumber(input: string): string {
   return replaceIfMatch(input, ORG_NUMBER_FORMAT, '$1 $2 $3');
 }
 
+const ACCOUNT_NUMBER_FORMAT = /^(\d{4})(\d{2})(\d{5})$/;
+
+/**
+ * Format a Norwegian account number
+ * @example
+ * ```
+ * formatAccountNumber('00000000000') // => '0000 00 00000'
+ * ```
+ */
+export function formatAccountNumber(input: string): string {
+  return replaceIfMatch(input, ACCOUNT_NUMBER_FORMAT, '$1 $2 $3');
+}
+
 const OBOS_MEMBERSHIP_NUMBER_FORMAT = /^(\d{3})(\d{2})(\d{2})$/;
 
 /**


### PR DESCRIPTION
## Summary

Adds Norwegian bank account number formatting to @obosbbl/format as a reusable formatter API.

## Changes

- Adds formatAccountNumber to the Norwegian formatter entrypoint.
- Exposes formatAccountNumber from the default entrypoint for locale: 'no'.
- Documents the new method in the package README.
- Adds formatter test coverage for raw, already formatted, dotted, and non-matching input.
- Adds a minor Changesets entry for @obosbbl/format.

## Context

This is the upstream follow-up for code-obos/styrerommet#9609, where norwegian-utils is being replaced and account-number formatting was identified as generally useful formatting behavior that belongs in @obosbbl/format rather than only in the Styrerommet shared package.

## Validation

- pnpm run lint:ci
- pnpm run test:ci
- pnpm run build